### PR TITLE
Add content to CODE_OF_CONDUCT.md and SECURITY.md files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as community members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+
+Community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+## Website Contribution Special Note
+
+When contributing to this repository, please be especially mindful of the special guidelines regarding the website code. As mentioned in the CONTRIBUTING.md document, certain parts of this repository are critical for the functioning of our community website and have special contribution requirements.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+Use this section to tell people about which versions of your project are currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.0.x   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+The Elmentor Landing Page team takes security vulnerabilities seriously. We appreciate your efforts to responsibly disclose your findings.
+
+To report a security issue, please follow these steps:
+
+1. **DO NOT** disclose the vulnerability publicly on GitHub Issues or other public forums.
+2. Send an email to [INSERT SECURITY EMAIL] with a detailed description of the vulnerability.
+3. Include steps to reproduce the vulnerability if possible.
+4. We will acknowledge receipt of your report within 48 hours.
+5. We will send you regular updates on our progress toward resolving the issue.
+6. Once the vulnerability is fixed, we will publicly acknowledge your responsible disclosure (unless you request otherwise).
+
+## Website Security Special Note
+
+This repository contains the live website for our community. Special care must be taken when suggesting or implementing security fixes that might affect the website's functionality. Please refer to the CONTRIBUTING.md document for guidelines on making changes to website-related code.
+
+## Security Best Practices for Contributors
+
+When contributing to this repository, please adhere to these security best practices:
+
+1. Never commit sensitive information such as API keys, passwords, or personal data.
+2. Keep all dependencies updated to their latest secure versions.
+3. Follow secure coding practices appropriate to the languages and frameworks used.
+4. Be cautious when introducing new dependencies to the project.


### PR DESCRIPTION
This PR adds content to previously empty files in accordance with DevOps Visions standards:

## Changes

- Added comprehensive Code of Conduct based on Contributor Covenant
- Added Security Policy with vulnerability reporting guidelines
- Added website-specific notes to both documents to ensure contributors are aware of special requirements

This addresses issue #7 and helps complete the repository structure per DevOps Visions guidance.

Fixes #7