### PR TITLE
Update README project structure to match actual repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ elmentor-landing-page-clean/
 ├── dist/              # Build output
 ├── docs/              # Documentation
 │   ├── deployment/    # Deployment documentation
+│   ├── design/        # Design documents
 │   ├── development/   # Development guides
-│   └── devops-visions-guidance/  # DevOps Visions standards
+│   ├── devops-visions-guidance/  # DevOps Visions standards
+│   └── legacy/        # Legacy documentation
 ├── public/            # Static assets [DO NOT MODIFY]
 ├── scripts/           # Utility scripts
 │   ├── deployment/    # Deployment scripts [DO NOT MODIFY]
@@ -53,7 +55,8 @@ elmentor-landing-page-clean/
 │   └── utils/         # Utility scripts
 ├── .github/           # GitHub templates and workflows
 │   ├── ISSUE_TEMPLATE/ # Issue templates
-│   └── PULL_REQUEST_TEMPLATE/ # PR templates
+│   ├── PULL_REQUEST_TEMPLATE/ # PR templates
+│   └── workflows/     # GitHub Actions workflows
 ├── .temp/             # Untracked local development files (not in Git)
 └── src/               # Source code [DO NOT MODIFY]
 ```


### PR DESCRIPTION
This PR updates the project structure diagram in the README.md to accurately reflect the actual repository structure.

## Changes

- Added docs/design/ and docs/legacy/ directories to structure diagram
- Added .github/workflows/ directory to structure diagram
- Ensures README structure accurately represents actual repository organization
- Maintains alignment with DevOps Visions guidance

This update ensures that new contributors have an accurate visual representation of the repository structure.

Fixes #13